### PR TITLE
Bugfix issue #5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quoll"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
     "jpype1==0.7.5",
     "pims==0.4.1",

--- a/src/quoll/frc/frc_calibration_functions.py
+++ b/src/quoll/frc/frc_calibration_functions.py
@@ -1,0 +1,35 @@
+# Copyright 2022 Rosalind Franklin Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+import numpy as np
+
+
+""" When adding calibration functions here, ensure that your function starts 
+with `calibration_func` or else it will not be discovered in the CLI/Napari"""
+
+def calibration_func_RFI(frequencies: list) -> list:
+    """ Calibration function to match 1 image FRC to 2 image FRC.
+
+    Redone for EM images.
+
+    Args:
+        frequencies (list): x-values in the FRC curve
+
+    Returns:
+        list: frequencies with correction factor applied
+    """
+    correction = 2.066688385682453 + 0.09896293544729941 * np.log(0.08470690336138625 * frequencies)
+    corrected_frequencies = frequencies / correction
+    return corrected_frequencies

--- a/src/quoll/frc/oneimg.py
+++ b/src/quoll/frc/oneimg.py
@@ -99,6 +99,22 @@ def miplib_oneimg_FRC_calibrated(
     return result
 
 
+def calibration_func_RFI(frequencies: list) -> list:
+    """ Calibration function to match 1 image FRC to 2 image FRC.
+
+    Redone for EM images.
+
+    Args:
+        frequencies (list): x-values in the FRC curve
+
+    Returns:
+        list: frequencies with correction factor applied
+    """
+    correction = 2.066688385682453 + 0.09896293544729941 * np.log(0.08470690336138625 * frequencies)
+    corrected_frequencies = frequencies / correction
+    return corrected_frequencies
+
+
 def calc_frc_res(
     Image: reader.Image,
     calibration_func: Optional[Callable] = None

--- a/src/quoll/frc/oneimg.py
+++ b/src/quoll/frc/oneimg.py
@@ -32,6 +32,7 @@ from miplib.data.containers.image import Image as miplibImage
 from miplib.data.io import read as miplibread
 from miplib.processing import windowing
 from quoll.io import reader, tiles
+from quoll.frc import frc_calibration_functions as cf
 
 
 def miplib_oneimg_FRC_calibrated(
@@ -96,22 +97,6 @@ def miplib_oneimg_FRC_calibrated(
     result = analyzer.execute(z_correction=z_correction)[0]
 
     return result
-
-
-def calibration_func_RFI(frequencies: list) -> list:
-    """ Calibration function to match 1 image FRC to 2 image FRC.
-
-    Redone for EM images.
-
-    Args:
-        frequencies (list): x-values in the FRC curve
-
-    Returns:
-        list: frequencies with correction factor applied
-    """
-    correction = 2.066688385682453 + 0.09896293544729941 * np.log(0.08470690336138625 * frequencies)
-    corrected_frequencies = frequencies / correction
-    return corrected_frequencies
 
 
 def calc_frc_res(

--- a/src/quoll/frc/oneimg.py
+++ b/src/quoll/frc/oneimg.py
@@ -99,22 +99,6 @@ def miplib_oneimg_FRC_calibrated(
     return result
 
 
-def calibration_func_RFI(frequencies: list) -> list:
-    """ Calibration function to match 1 image FRC to 2 image FRC.
-
-    Redone for EM images.
-
-    Args:
-        frequencies (list): x-values in the FRC curve
-
-    Returns:
-        list: frequencies with correction factor applied
-    """
-    correction = 2.066688385682453 + 0.09896293544729941 * np.log(0.08470690336138625 * frequencies)
-    corrected_frequencies = frequencies / correction
-    return corrected_frequencies
-
-
 def calc_frc_res(
     Image: reader.Image,
     calibration_func: Optional[Callable] = None

--- a/src/quoll/frc/oneimg.py
+++ b/src/quoll/frc/oneimg.py
@@ -98,7 +98,7 @@ def miplib_oneimg_FRC_calibrated(
     return result
 
 
-def calibration_func(frequencies: list) -> list:
+def calibration_func_RFI(frequencies: list) -> list:
     """ Calibration function to match 1 image FRC to 2 image FRC.
 
     Redone for EM images.
@@ -114,11 +114,18 @@ def calibration_func(frequencies: list) -> list:
     return corrected_frequencies
 
 
-def calc_frc_res(Image: reader.Image):
+def calc_frc_res(
+    Image: reader.Image,
+    calibration_func: Optional[Callable] = None
+    ):
     """Calculates one image FRC resolution for quoll Image object
 
     Args:
         Image (reader.Image): Quoll.io.reader.Image instance
+        calibration_func (callable): function that applies a correction factor to the
+                                    frequencies of the FRC curve to match the 1 img
+                                    FRC to the 2 img FRC. If None, no calibration is
+                                    applied.
 
     Raises:
         ValueError: if Image is not square
@@ -143,6 +150,7 @@ def calc_local_frc(
     Image: reader.Image,
     tile_size: int,
     tiles_dir: str,
+    calibration_func: Optional[Callable] = None
 ):
     """ Calculates local FRC on a quoll Image
 
@@ -152,6 +160,10 @@ def calc_local_frc(
         Image (reader.Image): Quoll.io.reader.Image instance
         tile_size (int): length of one side of the square tile in pixels
         tiles_dir (str): path to directory holding tiles
+        calibration_func (callable): function that applies a correction factor to the
+                                    frequencies of the FRC curve to match the 1 img
+                                    FRC to the 2 img FRC. If None, no calibration is
+                                    applied.
 
     Returns:
         pandas DataFrame: df containing the resolutions in physical units
@@ -165,7 +177,7 @@ def calc_local_frc(
     for tile in os.listdir(tiles_dir):
         try:
             Img = reader.Image(os.path.join(tiles_dir, tile))
-            result = calc_frc_res(Img)
+            result = calc_frc_res(Img, calibration_func)
             resolutions["Resolution"][tile] = result.resolution["resolution"]
         except:
             resolutions["Resolution"][tile] = np.nan

--- a/tests/test_frc_oneimg.py
+++ b/tests/test_frc_oneimg.py
@@ -41,7 +41,7 @@ class OneImgFRCTest(unittest.TestCase):
         result = oneimg.miplib_oneimg_FRC_calibrated(
             miplibImg,
             args,
-            oneimg.calibration_func_RFI
+            calibration_func=None
         )
 
         self.assertIsNotNone(result)
@@ -53,7 +53,7 @@ class OneImgFRCTest(unittest.TestCase):
         Img = reader.Image("./data/042.tif")
         result = oneimg.calc_frc_res(
             Image=Img,
-            calibration_func=oneimg.calibration_func_RFI
+            calibration_func=cf.calibration_func_RFI
         )
         self.assertAlmostEqual(result.resolution["resolution"], 32.1159278)
         self.assertIsNotNone(result)
@@ -80,7 +80,7 @@ class OneImgFRCTest(unittest.TestCase):
             Img,
             tile_size=512,
             tiles_dir="./data/tiles2/",
-            calibration_func=oneimg.calibration_func_RFI)
+            calibration_func=cf.calibration_func_RFI)
 
         # Check that tiles are created and saved
         self.assertNotEqual(len(os.listdir("./data/tiles2")), 0)

--- a/tests/test_frc_oneimg.py
+++ b/tests/test_frc_oneimg.py
@@ -40,7 +40,7 @@ class OneImgFRCTest(unittest.TestCase):
         result = oneimg.miplib_oneimg_FRC_calibrated(
             miplibImg,
             args,
-            oneimg.calibration_func
+            oneimg.calibration_func_RFI
         )
 
         self.assertIsNotNone(result)
@@ -50,7 +50,10 @@ class OneImgFRCTest(unittest.TestCase):
         Tests that the one-image FRC can be calculated from quoll.io.reader.Image
         """
         Img = reader.Image("./data/042.tif")
-        result = oneimg.calc_frc_res(Img)
+        result = oneimg.calc_frc_res(
+            Image=Img,
+            calibration_func=oneimg.calibration_func_RFI
+        )
         self.assertAlmostEqual(result.resolution["resolution"], 32.1159278)
         self.assertIsNotNone(result)
 
@@ -72,7 +75,11 @@ class OneImgFRCTest(unittest.TestCase):
             unit="nm"
         )
 
-        results_df = oneimg.calc_local_frc(Img, tile_size=512, tiles_dir="./data/tiles2/")
+        results_df = oneimg.calc_local_frc(
+            Img,
+            tile_size=512,
+            tiles_dir="./data/tiles2/",
+            calibration_func=oneimg.calibration_func_RFI)
 
         # Check that tiles are created and saved
         self.assertNotEqual(len(os.listdir("./data/tiles2")), 0)
@@ -93,3 +100,23 @@ class OneImgFRCTest(unittest.TestCase):
         # check that the resolution heatmap is not empty
         self.assertGreater(np.mean(resolution_heatmap), 0)
 
+    def test_set_calibration_func(self):
+        """
+        Tests that calibration function can be set to a custom function
+        In this test, calibration function is set to return the exact same 
+        value, so the result should be equal to uncalibrated.
+        """
+        Img = reader.Image("./data/042.tif")
+        result_calibrated = oneimg.calc_frc_res(
+            Image=Img,
+            calibration_func=lambda x: x  # just return original value
+        )
+        result_uncalibrated = oneimg.calc_frc_res(
+            Image=Img,
+            calibration_func=None
+        )
+        self.assertAlmostEqual(
+            result_calibrated.resolution["resolution"], 
+            result_uncalibrated.resolution["resolution"])
+        self.assertIsNotNone(result_calibrated.resolution["resolution"])
+        self.assertIsNotNone(result_uncalibrated.resolution["resolution"])

--- a/tests/test_frc_oneimg.py
+++ b/tests/test_frc_oneimg.py
@@ -41,7 +41,7 @@ class OneImgFRCTest(unittest.TestCase):
         result = oneimg.miplib_oneimg_FRC_calibrated(
             miplibImg,
             args,
-            calibration_func=None
+            oneimg.calibration_func_RFI
         )
 
         self.assertIsNotNone(result)
@@ -53,7 +53,7 @@ class OneImgFRCTest(unittest.TestCase):
         Img = reader.Image("./data/042.tif")
         result = oneimg.calc_frc_res(
             Image=Img,
-            calibration_func=cf.calibration_func_RFI
+            calibration_func=oneimg.calibration_func_RFI
         )
         self.assertAlmostEqual(result.resolution["resolution"], 32.1159278)
         self.assertIsNotNone(result)
@@ -80,7 +80,7 @@ class OneImgFRCTest(unittest.TestCase):
             Img,
             tile_size=512,
             tiles_dir="./data/tiles2/",
-            calibration_func=cf.calibration_func_RFI)
+            calibration_func=oneimg.calibration_func_RFI)
 
         # Check that tiles are created and saved
         self.assertNotEqual(len(os.listdir("./data/tiles2")), 0)
@@ -101,6 +101,26 @@ class OneImgFRCTest(unittest.TestCase):
         # check that the resolution heatmap is not empty
         self.assertGreater(np.mean(resolution_heatmap), 0)
 
+    def test_set_calibration_func(self):
+        """
+        Tests that calibration function can be set to a custom function
+        In this test, calibration function is set to return the exact same 
+        value, so the result should be equal to uncalibrated.
+        """
+        Img = reader.Image("./data/042.tif")
+        result_calibrated = oneimg.calc_frc_res(
+            Image=Img,
+            calibration_func=lambda x: x  # just return original value
+        )
+        result_uncalibrated = oneimg.calc_frc_res(
+            Image=Img,
+            calibration_func=None
+        )
+        self.assertAlmostEqual(
+            result_calibrated.resolution["resolution"], 
+            result_uncalibrated.resolution["resolution"])
+        self.assertIsNotNone(result_calibrated.resolution["resolution"])
+        self.assertIsNotNone(result_uncalibrated.resolution["resolution"])
     def test_set_calibration_func(self):
         """
         Tests that calibration function can be set to a custom function

--- a/tests/test_frc_oneimg.py
+++ b/tests/test_frc_oneimg.py
@@ -21,6 +21,7 @@ import numpy as np
 import miplib.ui.cli.miplib_entry_point_options as opts
 from miplib.data.io import read as miplibread
 from quoll.frc import oneimg
+from quoll.frc import frc_calibration_functions as cf
 from quoll.io import reader
 
 
@@ -40,7 +41,7 @@ class OneImgFRCTest(unittest.TestCase):
         result = oneimg.miplib_oneimg_FRC_calibrated(
             miplibImg,
             args,
-            oneimg.calibration_func_RFI
+            calibration_func=None
         )
 
         self.assertIsNotNone(result)
@@ -52,7 +53,7 @@ class OneImgFRCTest(unittest.TestCase):
         Img = reader.Image("./data/042.tif")
         result = oneimg.calc_frc_res(
             Image=Img,
-            calibration_func=oneimg.calibration_func_RFI
+            calibration_func=cf.calibration_func_RFI
         )
         self.assertAlmostEqual(result.resolution["resolution"], 32.1159278)
         self.assertIsNotNone(result)
@@ -79,7 +80,7 @@ class OneImgFRCTest(unittest.TestCase):
             Img,
             tile_size=512,
             tiles_dir="./data/tiles2/",
-            calibration_func=oneimg.calibration_func_RFI)
+            calibration_func=cf.calibration_func_RFI)
 
         # Check that tiles are created and saved
         self.assertNotEqual(len(os.listdir("./data/tiles2")), 0)

--- a/tests/test_frc_oneimg_cli_mock.py
+++ b/tests/test_frc_oneimg_cli_mock.py
@@ -76,6 +76,22 @@ class OneImgFRCCLIMockTest(unittest.TestCase):
         os.remove("./data/SerialFIB57_2048x2048_heatmap.tif")
         shutil.rmtree("./data/tiles", ignore_errors=True)
 
+    @mock.patch(
+        'sys.argv',
+        ["oneimgfrc",
+        "./data/042.tif",
+        "3.3724",
+        "-cf",
+        "calibration_func_RFI",
+        "--save_csv"],
+    )
+    def test_oneimgfrc_RFICalibrationFunc(self):
+        frc_oneimg_ui.oneimgfrc()
+        self.assertTrue(os.path.exists("./data/042_oneimgfrc.csv"))
+        with open("./data/042_oneimgfrc.csv", "r") as f:
+            self.assertAlmostEqual(float(f.read()), 32.11592783389754)
+        os.remove("./data/042_oneimgfrc.csv")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds the option to set the calibration function for one image FRC, closing #5 

## Usage

### Case 1: No calibration

#### If using the code directly

Set the `calibration_func` argument in `quoll.frc.oneimg.calc_local_frc` to None.

```
quoll.frc.oneimg.calc_local_frc(
    <img>, 
    <tile_size>, 
    <tiles_dir>,  
    calibration_func=None)
```

#### If using CLI

Run the `oneimgfrc` command in the terminal just passing `image_filename` and `pixel_size`.

### Case 3: Specifying a custom calibration function

#### If using the code directly

Note, you must be running a copy of the code locally for this to work.
In the future, there could be an option to host a copy of the calibration functions as a config file locally, so you can pip install quoll and not have to edit the source code directly.

In `src/quoll/frc/frc_calibration_functions.py` add a calibration function that corrects the frequencies from the one image FRC curve to that of the two image FRC. You will need a calibration dataset for the specific instrument, and the process for determining this calibration function will be described in a future guide. 

Add a calibration function which starts with "calibration_func" in its function name. You can use the `calibration_func_RFI` as an example.

Set the `calibration_func` argument in `quoll.frc.oneimg.calc_local_frc` to your function as defined in `quoll.frc.frc_calibration_functions`.

```
quoll.frc.oneimg.calc_local_frc(
    <img>, 
    <tile_size>, 
    <tiles_dir>, 
    calibration_func=quoll.frc.frc_calibration_functions.<custom_calibration_function>)
```

#### If using CLI

As above, add the custom calibration function into `src/quoll/frc/frc_calibration_functions.py`

Run the `oneimgfrc` command in the terminal with `-cf <custom_calibration_function>`. Here, all available calibration functions from `quoll.frc.frc_calibration_functions` are automatically discovered, if the function name starts with "calibration_func".


