### PR TITLE
Refactor to take out problematic dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,17 +6,15 @@ build-backend = "setuptools.build_meta"
 name = "quoll"
 version = "0.0.2"
 dependencies = [
-    "jpype1==0.7.5",
-    "pims==0.4.1",
     "matplotlib",
-    "miplib",
+    "miplib @ git+https://github.com/elainehoml/miplib.git@frc_deps_only",
     "mrcfile",
     "notebook",
     "numpy",
     "pandas",
     "scikit-image",
     "scipy",
-    "tifffile>2021",
+    "tifffile",
 ]
 authors = [
     {name="Elaine Ho", email="elaine.ho@rfi.ac.uk"}

--- a/src/quoll/frc/oneimg.py
+++ b/src/quoll/frc/oneimg.py
@@ -90,6 +90,9 @@ def miplib_oneimg_FRC_calibrated(
     # Apply correction
     if calibration_func is not None:
         frc_data[0].correlation["frequency"] = calibration_func(freqs)
+    
+    else:
+        frc_data[0].correlation["frequency"] = freqs
 
     # Analyze results
     analyzer = frc_analysis.FourierCorrelationAnalysis(

--- a/src/quoll/io/tiles.py
+++ b/src/quoll/io/tiles.py
@@ -76,7 +76,7 @@ def extract_tiles(Image, tile_size_x, tile_size_y, pad=True):
     return tiles, (nTilesX, nTilesY)
 
 
-def create_patches(Image, tile_size, tiles_output, pad=True):
+def create_patches(Image, tile_size, tiles_output=None, pad=True):
     """Split an image into square patches. All patches will be square if pad=True.
     Otherwise, patches at the edges do not fit neatly into the square patches will
     be returned (these are not square). Patches are saved as .tif's in tiles_output.
@@ -93,25 +93,31 @@ def create_patches(Image, tile_size, tiles_output, pad=True):
     tiles, (nTilesX, nTilesY) = extract_tiles(Image, tile_size, tile_size, pad)
     resolution = (1/Image.pixel_size, 1/Image.pixel_size)
 
-    if os.path.isdir(tiles_output) is False:
-        os.mkdir(tiles_output)
-    if len(os.listdir(tiles_output)) != 0:
-        for f in list(os.listdir(tiles_output)):
-            try:
-                os.remove(os.path.join(tiles_output, f))
-            except:
-                print(f"Could not remove {f}")
-    for i, tile in enumerate(tiles):
-        tile_fn = os.path.join(tiles_output, f"{i:03}.tif")
-        tifffile.imwrite(
-            tile_fn,
-            tile.astype('uint8'),
-            imagej=True,
-            resolution=resolution,
-            metadata={'unit': Image.unit}
-        )
+    if tiles_output is not None:
+        if os.path.isdir(tiles_output) is False:
+            os.mkdir(tiles_output)
+        if len(os.listdir(tiles_output)) != 0:
+            for f in list(os.listdir(tiles_output)):
+                try:
+                    os.remove(os.path.join(tiles_output, f))
+                except:
+                    print(f"Could not remove {f}")
+        for i, tile in enumerate(tiles):
+            tile_fn = os.path.join(tiles_output, f"{i:03}.tif")
+            tifffile.imwrite(
+                tile_fn,
+                tile.astype('uint8'),
+                imagej=True,
+                resolution=resolution,
+                metadata={'unit': Image.unit}
+            )
 
-        Image.tiles[tile_fn] = tile.astype('uint8')
+            Image.tiles[i] = tile.astype('uint8')
+
+    else:
+        for i, tile in enumerate(tiles):
+            Image.tiles[i] = tile.astype('uint8')
+    
     Image.tile_arrangement = (nTilesX, nTilesY)
 
 

--- a/tests/test_frc_oneimg.py
+++ b/tests/test_frc_oneimg.py
@@ -49,7 +49,7 @@ class OneImgFRCTest(unittest.TestCase):
         """
         Tests that the one-image FRC can be calculated from quoll.io.reader.Image
         """
-        Img = reader.Image("./data/042.tif")
+        Img = reader.Image("./data/042.tif", pixel_size=3.3724)
         result = oneimg.calc_frc_res(Img)
         self.assertAlmostEqual(result.resolution["resolution"], 32.1159278)
         self.assertIsNotNone(result)

--- a/tests/test_frc_oneimg.py
+++ b/tests/test_frc_oneimg.py
@@ -19,7 +19,8 @@ import unittest
 import numpy as np
 
 import miplib.ui.cli.miplib_entry_point_options as opts
-from miplib.data.io import read as miplibread
+# from miplib.data.io import read as miplibread
+from miplib.data.containers.image import Image as miplibImage
 from quoll.frc import oneimg
 from quoll.io import reader
 
@@ -29,21 +30,6 @@ class OneImgFRCTest(unittest.TestCase):
     Tests the one image FRC
     Test image = ChargeSuppression/SerialFIB-79, Tile 42
     """
-
-    def test_miplib_basic(self):
-        """
-        Tests that the adapted miplib one image FRC works with basic case
-        """
-        miplibImg = miplibread.get_image("./data/042.tif")
-        args = opts.get_frc_script_options([None])
-
-        result = oneimg.miplib_oneimg_FRC_calibrated(
-            miplibImg,
-            args,
-            oneimg.calibration_func
-        )
-
-        self.assertIsNotNone(result)
 
     def test_calc_frc_res(self):
         """

--- a/tests/test_frc_oneimg.py
+++ b/tests/test_frc_oneimg.py
@@ -93,27 +93,10 @@ class OneImgFRCTest(unittest.TestCase):
         In this test, calibration function is set to return the exact same 
         value, so the result should be equal to uncalibrated.
         """
-        Img = reader.Image("./data/042.tif")
-        result_calibrated = oneimg.calc_frc_res(
-            Image=Img,
-            calibration_func=lambda x: x  # just return original value
+        Img = reader.Image(
+            filename="./data/042.tif",
+            pixel_size=3.3724
         )
-        result_uncalibrated = oneimg.calc_frc_res(
-            Image=Img,
-            calibration_func=None
-        )
-        self.assertAlmostEqual(
-            result_calibrated.resolution["resolution"], 
-            result_uncalibrated.resolution["resolution"])
-        self.assertIsNotNone(result_calibrated.resolution["resolution"])
-        self.assertIsNotNone(result_uncalibrated.resolution["resolution"])
-    def test_set_calibration_func(self):
-        """
-        Tests that calibration function can be set to a custom function
-        In this test, calibration function is set to return the exact same 
-        value, so the result should be equal to uncalibrated.
-        """
-        Img = reader.Image("./data/042.tif")
         result_calibrated = oneimg.calc_frc_res(
             Image=Img,
             calibration_func=lambda x: x  # just return original value

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -15,6 +15,7 @@
 
 # Utility imports
 import unittest
+import numpy as np
 
 from quoll.io import reader
 
@@ -73,6 +74,21 @@ class ReaderTest(unittest.TestCase):
         self.assertEqual(Img.pixel_size, 13.12)
         self.assertEqual(Img.unit, "Angstrom")
         self.assertEqual(Img.img_dims, (41, 720, 512))
+
+    def test_reader_nparray_input(self):
+        """
+        Tests that Image can be created from np arrays
+        """
+        Img = reader.Image(
+            img_data=np.random.rand(5,10,10),
+            pixel_size=1.0,
+            unit="nm"
+        )
+
+        self.assertIsNone(Img.filename)
+        self.assertEqual(Img.img_dims, (5,10,10))
+        self.assertEqual(Img.pixel_size, 1.0)
+        self.assertEqual(Img.unit, "nm")
 
     def test_TS_importer_mrc_mdoc(self):
         """

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -52,7 +52,7 @@ class TilesTest(unittest.TestCase):
             Img,
             tile_size=128,
             tiles_output=tiles_dir,
-            pad=True
+            pad=True,
         )
 
         self.assertEqual(len(os.listdir(tiles_dir)), 4)
@@ -83,7 +83,7 @@ class TilesTest(unittest.TestCase):
             Img,
             tile_size=128,
             tiles_output=tiles_dir,
-            pad=True
+            pad=True,
         )
 
         reassembled = tiles.reassemble_tiles(


### PR DESCRIPTION
# Context

Currently, the input for frc calculation is the image filepath rather than the array containing image data, which makes Quoll harder to implement as a Napari plugin. Also, the filepath reading from Miplib uses pims which can complicate installation due to Java dependencies.

# Changes

Quoll now creates miplib Image objects directly from the image data, which is extracted from a Quoll Image object. The Quoll Image object only accepts .tiffs and .mrcs at the moment, rather than the wide range accepted from BioFormats through pims, though the installation of dependencies is easier. This change also makes Quoll more easily compatible with Napari plugin implementations.

Still need to have a look at the pyproject.toml and see how we can install a more minimal version of miplib that does not require the many + large dependencies we do not use and/or have trouble with: these include jpype1, pims, SimpleITK, psf, ...
