### PR TITLE
Run unittests on different versions of py

### DIFF
--- a/.github/workflows/python-unittest.yml
+++ b/.github/workflows/python-unittest.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Run unittests on py3.8, 3.9, 3.10.